### PR TITLE
feat: add intelligent multi-level cache for RevenueSentinel

### DIFF
--- a/docs/REVENUE_SENTINEL_CACHE_PLAN.md
+++ b/docs/REVENUE_SENTINEL_CACHE_PLAN.md
@@ -1,0 +1,105 @@
+# RevenueSentinel – Système de Cache Intelligent (L1 + L2)
+
+## 1) Architecture (Mermaid)
+
+```mermaid
+flowchart LR
+    A[RevenueSentinel Job Hourly] --> B{Cache L1\nIn-Memory LRU TTL}
+    B -- HIT <10ms --> Z[Return data]
+    B -- MISS --> C{Cache L2\nSQLite Durable}
+    C -- HIT ~2-8ms --> Z
+    C -- MISS --> D[Stripe/PayPal APIs]
+    D --> E[Normalize + Validate]
+    E --> F[Write-through L2]
+    F --> G[Update L1]
+    G --> Z
+
+    H[Stripe/PayPal Webhooks] --> I[Verify Signature]
+    I --> J[Map event -> campaign/provider keys]
+    J --> K[Invalidate Prefix/Key L1+L2]
+```
+
+### ASCII quick view
+
+```text
+Caller -> L1(memory) -> L2(SQLite) -> Provider API
+           | hit fast      | warm hit       | miss only
+Webhook -------------------------------> invalidate keys
+```
+
+## 2) Code Python (classe `RevenueCache`)
+
+Implémentation prête à intégrer dans `src/revenue_sentinel.py`:
+- L1: `OrderedDict` (LRU + TTL)
+- L2: SQLite (`cache_entries`)
+- `get_or_set` avec fallback stale-if-error
+- invalidation ciblée (`invalidate`, `invalidate_prefix`)
+- métriques (`hit_ratio`, `provider_calls`, etc.)
+
+Voir le fichier code: `src/revenue_sentinel.py`.
+
+## 3) Stratégie webhook (Stripe/PayPal -> invalidation)
+
+1. Vérifier les signatures webhook (obligatoire).
+2. Mapper l’événement aux clés cache:
+   - `provider` (stripe/paypal)
+   - `campaign_id` (metadata)
+   - `period` (ex: `1h`, `24h`)
+3. Invalider granularité fine:
+   - clé unique si possible
+   - sinon `invalidate_prefix(f"{provider}:{campaign_id}:")`
+4. Requête suivante => refresh automatique (cache miss contrôlé).
+
+### Exemple pseudo-code webhook
+
+```python
+# event = parsed webhook payload
+provider = "stripe"
+campaign_id = event["data"]["object"]["metadata"]["campaign_id"]
+cache.invalidate_prefix(f"{provider}:{campaign_id}:")
+```
+
+## 4) Configuration recommandée
+
+- `ttl_seconds`: `3600` (job horaire)
+- `l1_max_items`: `1000` (ajuster selon RAM)
+- `sqlite_path`: `./data/revenue_cache.sqlite3`
+- `stale_if_error_seconds`: `21600` (6h)
+
+### Justification objectif 80%
+
+- Avec requêtes répétitives par campagne/période, L1 + L2 évitent les appels redondants.
+- Webhook invalidation garde les données fraîches sans polling agressif.
+- Cible réaliste:
+  - `hit_ratio >= 0.80`
+  - `provider_calls / total_reads <= 0.20`
+
+## 5) Monitoring / métriques
+
+Exporter `cache.metrics()` toutes les 60s:
+
+- `l1_hits`, `l2_hits`, `misses`
+- `provider_calls`
+- `hit_ratio`
+- `invalidations`
+- `stale_served` (résilience)
+- `errors`
+- `l1_size`
+
+### SLOs cibles
+
+- Cache hit latency: `<10ms` (L1)
+- API call reduction: `>=80%`
+- Reliability: `100%` service continuity (stale-if-error + L2 durable)
+
+## Intégration rapide dans `src/revenue_sentinel.py`
+
+```python
+cache = RevenueCache(CacheConfig())
+key = make_cache_key("stripe", campaign_id="cmp_42", period="1h")
+
+payload = cache.get_or_set(
+    key,
+    provider_fn=lambda: stripe_client.fetch_campaign_revenue("cmp_42", "1h"),
+)
+```

--- a/src/revenue_sentinel.py
+++ b/src/revenue_sentinel.py
@@ -1,0 +1,262 @@
+"""RevenueSentinel cache layer.
+
+Multi-level cache design:
+- L1: in-memory OrderedDict (LRU + TTL)
+- L2: SQLite persistence for durability across restarts
+
+Goal: reduce Stripe/PayPal API calls by serving hot keys from L1 and warm keys
+from L2 before falling back to provider calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Runtime knobs for cache behavior."""
+
+    ttl_seconds: int = 3600
+    l1_max_items: int = 1024
+    sqlite_path: str = "./data/revenue_cache.sqlite3"
+    stale_if_error_seconds: int = 21600
+
+
+class RevenueCache:
+    """Two-level cache for RevenueSentinel payment/revenue payloads.
+
+    Public methods are thread-safe for a single process thanks to an RLock.
+    L2 persistence ensures no full cache loss on process restarts.
+    """
+
+    def __init__(self, config: Optional[CacheConfig] = None) -> None:
+        self.config = config or CacheConfig()
+        self._lock = threading.RLock()
+        self._l1: "OrderedDict[str, tuple[float, Any]]" = OrderedDict()
+
+        # Observability counters.
+        self._metrics: Dict[str, int] = {
+            "l1_hits": 0,
+            "l2_hits": 0,
+            "misses": 0,
+            "sets": 0,
+            "provider_calls": 0,
+            "invalidations": 0,
+            "stale_served": 0,
+            "errors": 0,
+        }
+
+        self._init_sqlite()
+
+    def _init_sqlite(self) -> None:
+        path = Path(self.config.sqlite_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache_entries (
+                    key TEXT PRIMARY KEY,
+                    value_json TEXT NOT NULL,
+                    expires_at REAL NOT NULL,
+                    updated_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cache_expires ON cache_entries(expires_at)"
+            )
+            conn.commit()
+
+    def _db(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.config.sqlite_path)
+
+    def get(self, key: str) -> Optional[Any]:
+        """Read from L1 first, then L2, respecting TTL."""
+        now = time.time()
+
+        with self._lock:
+            if key in self._l1:
+                expires_at, value = self._l1[key]
+                if expires_at > now:
+                    self._l1.move_to_end(key)
+                    self._metrics["l1_hits"] += 1
+                    return value
+                # Expired in L1: remove and continue to L2.
+                self._l1.pop(key, None)
+
+            payload = self._get_from_l2(key)
+            if payload is not None:
+                expires_at, value = payload
+                self._l1_set(key, expires_at, value)
+                self._metrics["l2_hits"] += 1
+                return value
+
+            self._metrics["misses"] += 1
+            return None
+
+    def set(self, key: str, value: Any, ttl_seconds: Optional[int] = None) -> None:
+        """Write-through in L1 and L2 to keep persistence and speed."""
+        ttl = ttl_seconds if ttl_seconds is not None else self.config.ttl_seconds
+        expires_at = time.time() + ttl
+
+        with self._lock:
+            self._l1_set(key, expires_at, value)
+            self._set_l2(key, expires_at, value)
+            self._metrics["sets"] += 1
+
+    def get_or_set(self, key: str, provider_fn: Callable[[], Any]) -> Any:
+        """Return cached value or fetch provider and store.
+
+        If provider call fails, serve a recently stale value from L2 when possible
+        (`stale_if_error_seconds`) to maximize reliability.
+        """
+        cached = self.get(key)
+        if cached is not None:
+            return cached
+
+        self._metrics["provider_calls"] += 1
+        try:
+            value = provider_fn()
+        except Exception:
+            self._metrics["errors"] += 1
+            stale = self._get_stale_if_error(key)
+            if stale is not None:
+                self._metrics["stale_served"] += 1
+                return stale
+            raise
+
+        self.set(key, value)
+        return value
+
+    def invalidate(self, key: str) -> None:
+        """Remove a single cache entry from both levels."""
+        with self._lock:
+            self._l1.pop(key, None)
+            with self._db() as conn:
+                conn.execute("DELETE FROM cache_entries WHERE key = ?", (key,))
+                conn.commit()
+            self._metrics["invalidations"] += 1
+
+    def invalidate_prefix(self, prefix: str) -> int:
+        """Invalidate a campaign/provider namespace. Returns deleted count."""
+        deleted = 0
+        with self._lock:
+            for key in list(self._l1.keys()):
+                if key.startswith(prefix):
+                    self._l1.pop(key, None)
+                    deleted += 1
+
+            with self._db() as conn:
+                cur = conn.execute("DELETE FROM cache_entries WHERE key LIKE ?", (f"{prefix}%",))
+                deleted += cur.rowcount if cur.rowcount > 0 else 0
+                conn.commit()
+
+            self._metrics["invalidations"] += deleted
+        return deleted
+
+    def purge_expired(self) -> int:
+        """Periodic cleanup for L1 and L2 expired entries."""
+        now = time.time()
+        removed = 0
+        with self._lock:
+            for key, (expires_at, _value) in list(self._l1.items()):
+                if expires_at <= now:
+                    self._l1.pop(key, None)
+                    removed += 1
+
+            with self._db() as conn:
+                cur = conn.execute("DELETE FROM cache_entries WHERE expires_at <= ?", (now,))
+                removed += cur.rowcount if cur.rowcount > 0 else 0
+                conn.commit()
+        return removed
+
+    def metrics(self) -> Dict[str, Any]:
+        """Return counters + hit ratio for monitoring export."""
+        with self._lock:
+            total_reads = self._metrics["l1_hits"] + self._metrics["l2_hits"] + self._metrics["misses"]
+            hit_ratio = (
+                (self._metrics["l1_hits"] + self._metrics["l2_hits"]) / total_reads
+                if total_reads
+                else 0.0
+            )
+            return {
+                **self._metrics,
+                "l1_size": len(self._l1),
+                "hit_ratio": round(hit_ratio, 4),
+            }
+
+    # --- Internal helpers ---
+
+    def _l1_set(self, key: str, expires_at: float, value: Any) -> None:
+        self._l1[key] = (expires_at, value)
+        self._l1.move_to_end(key)
+
+        while len(self._l1) > self.config.l1_max_items:
+            self._l1.popitem(last=False)
+
+    def _get_from_l2(self, key: str) -> Optional[tuple[float, Any]]:
+        now = time.time()
+        with self._db() as conn:
+            row = conn.execute(
+                "SELECT value_json, expires_at FROM cache_entries WHERE key = ?", (key,)
+            ).fetchone()
+
+        if not row:
+            return None
+
+        value_json, expires_at = row
+        if expires_at <= now:
+            return None
+
+        return expires_at, json.loads(value_json)
+
+    def _get_stale_if_error(self, key: str) -> Optional[Any]:
+        threshold = time.time() - self.config.stale_if_error_seconds
+        with self._db() as conn:
+            row = conn.execute(
+                """
+                SELECT value_json, expires_at
+                FROM cache_entries
+                WHERE key = ?
+                """,
+                (key,),
+            ).fetchone()
+
+        if not row:
+            return None
+
+        value_json, expires_at = row
+        if expires_at < threshold:
+            return None
+
+        return json.loads(value_json)
+
+    def _set_l2(self, key: str, expires_at: float, value: Any) -> None:
+        value_json = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+        now = time.time()
+        with self._db() as conn:
+            conn.execute(
+                """
+                INSERT INTO cache_entries (key, value_json, expires_at, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value_json=excluded.value_json,
+                    expires_at=excluded.expires_at,
+                    updated_at=excluded.updated_at
+                """,
+                (key, value_json, expires_at, now),
+            )
+            conn.commit()
+
+
+def make_cache_key(provider: str, campaign_id: str, period: str) -> str:
+    """Canonical cache key builder used by RevenueSentinel callers."""
+    return f"{provider}:{campaign_id}:{period}".lower()

--- a/tests/test_revenue_cache.py
+++ b/tests/test_revenue_cache.py
@@ -1,0 +1,62 @@
+import tempfile
+import time
+import unittest
+
+from src.revenue_sentinel import CacheConfig, RevenueCache, make_cache_key
+
+
+class RevenueCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        sqlite_path = f"{self.tmp.name}/cache.sqlite3"
+        self.cache = RevenueCache(CacheConfig(ttl_seconds=1, l1_max_items=2, sqlite_path=sqlite_path))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_set_get_l1_hit(self):
+        key = make_cache_key("stripe", "campaign-a", "1h")
+        self.cache.set(key, {"amount": 12})
+        value = self.cache.get(key)
+        self.assertEqual(value["amount"], 12)
+        self.assertEqual(self.cache.metrics()["l1_hits"], 1)
+
+    def test_l2_hit_after_l1_eviction(self):
+        self.cache.set("a", {"v": 1})
+        self.cache.set("b", {"v": 2})
+        self.cache.set("c", {"v": 3})
+        value = self.cache.get("a")
+        self.assertEqual(value["v"], 1)
+        self.assertEqual(self.cache.metrics()["l2_hits"], 1)
+
+    def test_get_or_set_provider_call_count(self):
+        calls = {"n": 0}
+
+        def provider():
+            calls["n"] += 1
+            return {"ok": True}
+
+        self.cache.get_or_set("k", provider)
+        self.cache.get_or_set("k", provider)
+
+        self.assertEqual(calls["n"], 1)
+        self.assertEqual(self.cache.metrics()["provider_calls"], 1)
+
+    def test_stale_if_error(self):
+        self.cache.set("err-k", {"value": 99}, ttl_seconds=0)
+
+        def broken():
+            raise RuntimeError("provider down")
+
+        data = self.cache.get_or_set("err-k", broken)
+        self.assertEqual(data["value"], 99)
+        self.assertEqual(self.cache.metrics()["stale_served"], 1)
+
+    def test_ttl_expiry(self):
+        self.cache.set("ttl", {"x": 1}, ttl_seconds=1)
+        time.sleep(1.05)
+        self.assertIsNone(self.cache.get("ttl"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Reduce Stripe/PayPal API calls for RevenueSentinel by serving hot/warm keys from a local cache to avoid rate limiting and latency spikes.  
- Provide durability across process restarts with a persistent L2 so cached data is not lost and the system remains reliable.  
- Offer webhook-driven invalidation and `stale_if_error` fallback to maintain continuity (<10ms L1 hits target) during provider outages.

### Description
- Add a production-ready `RevenueCache` class in `src/revenue_sentinel.py` implementing a two-level cache: L1 in-memory `OrderedDict` (LRU + TTL) and L2 SQLite persistence, with thread-safety via `RLock`.  
- Implement public APIs `get`, `set`, `get_or_set`, `invalidate`, `invalidate_prefix`, `purge_expired`, and `metrics`, plus helper `make_cache_key(provider, campaign_id, period)`.  
- Add documentation `docs/REVENUE_SENTINEL_CACHE_PLAN.md` with a Mermaid architecture diagram, ASCII overview, webhook invalidation strategy, recommended configuration (`ttl_seconds`, `l1_max_items`, `sqlite_path`, `stale_if_error_seconds`), and monitoring guidance.  
- Include unit tests in `tests/test_revenue_cache.py` that validate L1 hits, L2 fallback after eviction, provider-call reduction via `get_or_set`, stale-if-error serving, and TTL expiry behavior.

### Testing
- Ran unit tests with `python -m unittest -v tests/test_revenue_cache.py` and all tests passed (5 tests, including L1 hit, L2 fallback, provider call count, stale-if-error and TTL expiry).  
- The test run completed successfully (`OK`) and finished in approximately 1.17s.  
- The `metrics()` method is available for exporting monitoring counters (`l1_hits`, `l2_hits`, `misses`, `provider_calls`, `hit_ratio`, `invalidations`, `stale_served`, `errors`, `l1_size`) for ongoing validation of the 80% API reduction goal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df4be5f2c832f9dc2ccef0fe03f8c)